### PR TITLE
Check Pano ID to avoid unofficial coverage

### DIFF
--- a/src/utils/SVreq.js
+++ b/src/utils/SVreq.js
@@ -16,6 +16,7 @@ export default function SVreq(loc, settings) {
 			const toDate = Date.parse(settings.toDate);
 			let dateWithin = false;
 			for (var i = 0; i < res.time.length; i++) {
+				if (settings.rejectUnofficial && res.time[i].pano.length != 22) continue; // Checks if pano ID is 22 characters long. Otherwise, it's an Ari
 				const iDate = Date.parse(res.time[i].jm.getFullYear() + "-" + (res.time[i].jm.getMonth() + 1));
 				if (iDate >= fromDate && iDate <= toDate) {
 					dateWithin = true;


### PR DESCRIPTION
Avoids coverage like this <https://goo.gl/maps/aseTHaDk2SECxfy49>, where a new Ari overrides older Google coverage